### PR TITLE
Add osu! and Rhythm game category

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Open source games that have the source code available on GitHub.
 - [Native](#native)
 	- [Action](#action)
 	- [Arcade](#arcade-1)
+	- [Rhythm](#rhythm)
 	- [FPS](#fps-1)
 	- [MMORPG](#mmorpg-1)
 	- [RPG](#rpg-1)
@@ -259,6 +260,10 @@ A selection of major game studios, publishers, etc. using GitHub:
 - [Wannabe Tempest](https://github.com/awlzac/wbt) - Tempest(80's arcade game) clone in Java, and a small project for playing with git.
 - [Witch Blast](https://github.com/Cirrus-Minor/witchblast) - Roguelite dungeon crawl shooter similar to The Binding of Isaac.
 
+### Rhythm
+
+- [osu!](https://github.com/ppy/osu) - Rhythm is just a *click* away!
+
 ### FPS
 
 - [AssaultCube](https://github.com/assaultcube/AC) - Total conversion of Wouter van Oortmerssen's FPS called Cube.
@@ -482,6 +487,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 - [MonoGame](https://github.com/mono/MonoGame) - XNA Implementation for Mono based platforms (supports iOS, Android, Linux, and started work on PS Suite and NaCli ).
 - [Oimo.js](https://github.com/lo-th/Oimo.js) - Lightweight 3d physics engine for JavaScript.
 - [OpenRTS](https://github.com/methusalah/OpenRTS) - Real-Time Strategy game 3D engine coded in java 7.
+- [osu-framework](https://github.com/ppy/osu-framework) - A game framework written with osu! in mind.
 - [Oxygine](https://github.com/oxygine/oxygine-framework) - C++ engine and framework for 2D games on iOS, Android, Windows, Linux and Mac.
 - [panda.js](https://github.com/ekelokorpi/panda.js) - Free HTML5 game engine for mobile and desktop with Canvas and WebGL rendering.
 - [Phaser](https://github.com/photonstorm/phaser) - Phaser is a fun, free and fast 2D game framework for making HTML5 games for desktop and mobile web browsers, supporting Canvas and WebGL rendering.


### PR DESCRIPTION
osu! repository found on github contains the new "lazer" that is current set to replace the old stable client in the future
The project is split into two repos osu and osu-framework
osu-framework has been Frameworks/Engines/Libraries section while osu has been added to the newly created rhythm game category
BTW this is my first ever pull request so tell me if I did something stupid