### PR TITLE
Adds Project: Starfighter, reTux and Super Bombinhas

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,12 +225,13 @@ A selection of major game studios, publishers, etc. using GitHub:
 
 - [Beast](https://github.com/dominikwilkowski/beast.js) - An homage to the 1984 ASCII game "BEAST" from Dan Baker, Alan Brown, Mark Hamilton and Derrick Shadel written in node. You have to squash little ASCII beasts between pushable blocks but watch you to not be eaten by them.
 - [Binb](https://github.com/lpinca/binb) - Competitive, multiplayer, realtime, guess the song game.
+- [CyberPong](https://github.com/dreamtocode/Cyber-Pong) - Unusual Ping Pong game, adaptable with Makey Makey Kit.
 - [Dental Defender: Saga of the Candy Horde](https://github.com/cshepp/candyjam) - HTML5 shooter/tower defense game for the #CandyJam.
 - [Descensus 2](https://github.com/TomWHall/Descensus2) - A TypeScript 2D physics game.
 - [Hauberk](https://github.com/munificent/hauberk) - Hauberk is a roguelike, an ASCII-art based procedurally-generated dungeon crawl game. It's written in Dart and runs in your browser.
 - [HeartLine](https://github.com/gamebytes/heartline.github.com) - Game made in 48 hours for the 2013 Global Game Jam.
+- [Project: Starfighter](https://github.com/pr-starfighter/starfighter) - Space shoot 'em up game
 - [Psiral](https://github.com/petarov/game-off-2013) - JavaScript/HTML5 game, GitHub Game Off 2 winner.
-- [CyberPong](https://github.com/dreamtocode/Cyber-Pong) - Unusual Ping Pong game, adaptable with Makey Makey Kit.
 - [Squirts](https://github.com/KrofDrakula/squirts) - Well-known indie game implemented in JavaScript.
 - [The Killer](https://github.com/JordanMagnuson/The-Killer) - Flash/ActionScript3-based "nongame".
 - [Turkey Cooking Simulator](https://github.com/fernjager/game-off-2013) - You have been invited to craft the centerpiece of the American thanksgiving dinner, the turkey. Woo your girlfriend / boyfriend and be judged by your future in-laws! Apply your culinary expertise to impress your family.
@@ -318,6 +319,8 @@ A selection of major game studios, publishers, etc. using GitHub:
 - [Sky Engine](https://github.com/ilenburg/game-engine) - Custom engine 2D platform game made with OpenGL.
 - [The Legend of Edgar](https://github.com/riksweeney/edgar) - 2D platform game with a persistent world.
 - [The Secret Chronicles of Dr. M.](https://github.com/Secretchronicles/TSC) - A 2D platform game in classic style.
+- [ReTux](https://github.com/retux-game/retux/) - Platformer game inspired by SuperTux
+- [Super Bombinhas](https://github.com/victords/super-bombinhas) - Retro platformer game
 - [SuperTux](https://github.com/SuperTux/supertux) - Classic 2D jump'n'run sidescroller with Tux.
 
 ### Puzzle/card/board


### PR DESCRIPTION
I would also add [Librerama](https://codeberg.org/Librerama/librerama/), but I read that you only accept projects hosted on GitHub ("Collection of Games that have the source code available on GitHub").