### PR TITLE
Add Rogue Legacy 1 source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 - [Prince of Persia](https://github.com/jmechner/Prince-of-Persia-Apple-II) - Source code for the original Prince of Persia game that was written on the Apple II, in 6502 assembly language, between 1985-89.
 - [UFO RUN](https://github.com/Nextpeer/Nextpeer-UFORUN) - Real time multiplayer with Nextpeer.
 - [System Shock](https://github.com/NightDiveStudios/shockmac) - Source code for original System Shock game (PowerMac version), more readable fork available [here](https://github.com/ToxicFrog/shockmac).
+- [Rogue Legacy](https://github.com/flibitijibibo/RogueLegacy1/) - Source code for Rogue Legacy 1.
 
 ## Frameworks/Engines/Libraries
 


### PR DESCRIPTION
The source for Rogue Legacy 1 was released a few weeks ago! Added a link to the repository hosted here: [https://github.com/flibitijibibo/RogueLegacy1/](https://github.com/flibitijibibo/RogueLegacy1/)