### PR TITLE
Add Wolfcha to Browser-Based Boardgame section

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 - [Green Mahjong](https://github.com/danbeck/green-mahjong) - Solitaire mahjong game done in HTML/CSS/JavaScript.
 - [Kriegspiel](https://github.com/binarymax/kriegspiel) - The game of imperfect information, the Kriegspiel chess variant.
 - [Lichess](https://github.com/ornicar/lila) - Free chess game using HTML5 & websockets built with Scala, Play 2.8, MongoDB and Elasticsearch.
+- [Wolfcha](https://github.com/oil-oil/wolfcha) - AI-powered Werewolf (Mafia) social deduction game where every player is controlled by top LLMs. Built with Next.js and TypeScript.
 
 
 ### Arcade


### PR DESCRIPTION
[Wolfcha](https://github.com/oil-oil/wolfcha) is an open-source AI-powered Werewolf (Mafia) social deduction game where every player except you is controlled by top AI models (DeepSeek, Qwen, Gemini, etc.). Built with Next.js, TypeScript, and Tailwind CSS.

Features 8 game roles, dual-layer AI roleplay, bilingual support (EN/CN), voice TTS, and game analysis.

Live: https://wolf-cha.com