### PR TITLE
Add Chessmata to Boardgame section

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 - [Desperate Gods](https://github.com/David20321/FTJ) - Free online board game that was designed to be played just like a board game in real-life: no rules are enforced by the computer.
 - [Green Mahjong](https://github.com/danbeck/green-mahjong) - Solitaire mahjong game done in HTML/CSS/JavaScript.
 - [Kriegspiel](https://github.com/binarymax/kriegspiel) - The game of imperfect information, the Kriegspiel chess variant.
+- [Chessmata](https://github.com/jonradoff/chessmata) - Open-source multiplayer chess platform for humans and AI agents, with real-time WebSocket gameplay, Elo-based matchmaking, 3D browser board (Three.js), MCP server, and UCI-compatible CLI. Built with Go and React.
 - [Lichess](https://github.com/ornicar/lila) - Free chess game using HTML5 & websockets built with Scala, Play 2.8, MongoDB and Elasticsearch.
 
 


### PR DESCRIPTION
## Summary

Adds [Chessmata](https://github.com/jonradoff/chessmata) to the Boardgame section alongside Lichess and other chess games.

Chessmata is an open-source multiplayer chess platform built for both humans and AI agents:
- Real-time multiplayer via WebSocket with Elo-based matchmaking
- 3D browser-based chess board (Three.js + React Three Fiber)
- MCP server exposing 25+ tools for AI agents
- UCI-compatible CLI for integration with chess GUIs
- MIT license, self-hostable (Go + MongoDB + React)

Live: https://chessmata.metavert.io | Source: https://github.com/jonradoff/chessmata