### PR TITLE
Add Legend of Elya — World's first LLM on Nintendo 64

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 - [Shattered Pixel Dungeon](https://shatteredpixel.com/shatteredpd/) - An open source game based on the source code of Pixel Dungeon by Watabou.
 - [The Legend of Zelda: Mystery of Solarus DX](https://github.com/christopho/zsdx) - Sequel to The Legend of Zelda: A Link to the Past released on the SNES.
 - [Valyria Tear](https://github.com/Bertram25/ValyriaTear) - Single-player medieval-fantasy 2D J-RPG.
+- [Legend of Elya](https://github.com/Scottcjn/legend-of-elya-n64) - World's first LLM on Nintendo 64. 819K-parameter nano-GPT transformer running live inference on MIPS R4300i at 60 tok/s. Zelda-style dungeon crawler with AI NPCs. Built with libdragon SDK.
 
 ### Platform
 


### PR DESCRIPTION
## Summary

Adds [Legend of Elya](https://github.com/Scottcjn/legend-of-elya-n64) to the Native > RPG section.

**Legend of Elya** is the world's first LLM running on Nintendo 64 hardware — an 819K-parameter nano-GPT transformer running live inference on the MIPS R4300i FPU at 60 tokens/second. It's a Zelda-style dungeon crawler with AI NPCs that respond dynamically using on-device neural network inference. Built with the libdragon SDK.

- Full source code available on GitHub
- Produces a playable .z64 ROM
- Uses the N64's RSP for matrix multiplication acceleration
- Featured in the awesome-n64-development list

This fits the Native > RPG category as an open-source RPG/dungeon crawler game.