### PR TITLE
Add Legends of Future Past (Browser-Based MMORPG)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 
 - [BrowserQuest](https://github.com/mozilla/BrowserQuest) - HTML5/JavaScript multiplayer game experiment.
 - [Reia](https://www.playreia.com) - RPG game action-adventure MMO focusing heavily on story, combat, and an open-world sandox adventure. Built with Godot, Rust, and Zig.
+- [Legends of Future Past](https://github.com/jonradoff/lofp) - Resurrected 1992 commercial MUD with combat, magic, psionics, crafting, and 2000+ rooms. Go + React + WebSocket. [Play free](https://lofp.metavert.io).
 
 ### Strategy
 - [Ancient Beast](https://github.com/FreezingMoon/AncientBeast) - Materialize and control beasts in order to defeat your opponents.
@@ -297,6 +298,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 
 - [Meridian 59](https://github.com/Meridian59/Meridian59) - The first 3D MMORPG, released in 1996 and open sourced in 2012 - the game is being actively developed by the community.
 - [Reia](https://github.com/Quaint-Studios/Reia) - RPG game action-adventure MMO focusing heavily on story, combat, and an open-world sandox adventure. Built with Godot, Rust, and Zig.
+- [Legends of Future Past](https://github.com/jonradoff/lofp) - Resurrected 1992 commercial MUD with combat, magic, psionics, crafting, and 2000+ rooms. Go + React + WebSocket. [Play free](https://lofp.metavert.io).
 - [Stendhal](https://github.com/arianne/stendhal) - Fun friendly and free 2D multiplayer online adventure game with an old school feel.
 - [Veloren](https://veloren.net/) - An action-adventure role-playing game set in a vast fantasy world.
 


### PR DESCRIPTION
Adding Legends of Future Past to the Browser-Based MMORPG section.

A 1992 commercial MUD (one of the earliest online multiplayer games) that was faithfully resurrected from its original script files in 2026. Won Computer Gaming World's 1993 Special Award for Artistic Excellence.

- **Tech**: Go + React + TypeScript + MongoDB + WebSocket
- **License**: MIT
- **Play now**: https://lofp.metavert.io
- **GitHub**: https://github.com/jonradoff/lofp
- **Wikipedia**: https://en.wikipedia.org/wiki/Legends_of_Future_Past