### PR TITLE
Add Blocks Beyond the Stars (Native / Sandbox)

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 ### Sandbox
 
 - [Blackvoxel](https://github.com/Blackvoxel/Blackvoxel) - Sandbox game based on a molecular voxel interaction engine.
+- [Blocks Beyond the Stars](https://github.com/marceld23/BlocksBeyondTheStars) - Block-based 3D space crafting sandbox with procedurally generated planets, block-by-block ship & base building and self-hostable multiplayer (Unity client, .NET server).
 - [Craft](https://github.com/fogleman/Craft) - Simple Minecraft clone written in C using modern OpenGL.
 - [Endless Sky](https://github.com/endless-sky/endless-sky) - Space trading and combat game similar to the classic Escape Velocity series.
 - [Freeminer](https://github.com/freeminer/freeminer) - Sandbox game inspired by Minecraft.


### PR DESCRIPTION
Adds **Blocks Beyond the Stars** to Native → Sandbox (alphabetical order, after Blackvoxel).

Free, open-source (AGPL-3.0) 3D voxel space crafting game: procedurally generated star systems and planets, mining, crafting, creature taming, ship/base/station building and self-hostable multiplayer servers. Unity client + authoritative .NET server; playable builds for Windows and Linux (experimental macOS, browser client).

- Source: https://github.com/marceld23/BlocksBeyondTheStars
- Website: https://www.blocksbeyondthestars.com/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)