### PR TITLE
Add Daily Word Hunt (browser daily word search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 
 - [3D Hartwing Chess Set](https://github.com/juliangarnier/3D-Hartwig-chess-set) - 3D chess game done in HTML/CSS/JavaScript.
 - [c4](https://github.com/kenrick95/c4) - Connect Four game where player is playing against an AI.
+- [Daily Word Hunt](https://github.com/s87343472/daily-word-hunt) - Free browser daily word search (find-the-word). New puzzle every day, themed series, print packs. [Play](https://words.sagasu.art/)
 - [Desperate Gods](https://github.com/David20321/FTJ) - Free online board game that was designed to be played just like a board game in real-life: no rules are enforced by the computer.
 - [Duet (Veiled Dominion)](https://github.com/Loptr-Lab/duet-solo-hackathon) - Open-source asymmetric chess variant with an inverted win condition — the game ends when your transformed piece loses control, not when your immobile king is threatened. Includes an AI opponent, remote multiplayer, and an optional fog-of-war mode.
 - [Green Mahjong](https://github.com/danbeck/green-mahjong) - Solitaire mahjong game done in HTML/CSS/JavaScript.


### PR DESCRIPTION
Adds [Daily Word Hunt](https://github.com/s87343472/daily-word-hunt) under Browser-Based.

- Live: https://words.sagasu.art/
- Free daily word search; themed series; print packs; MIT.