### PR TITLE
Add Pip to Browser-Based / Boardgame

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 - [Kriegspiel](https://github.com/binarymax/kriegspiel) - The game of imperfect information, the Kriegspiel chess variant.
 - [Chessmata](https://github.com/jonradoff/chessmata) - Open-source multiplayer chess platform for humans and AI agents, with real-time WebSocket gameplay, Elo-based matchmaking, 3D browser board (Three.js), MCP server, and UCI-compatible CLI. Built with Go and React.
 - [Lichess](https://github.com/ornicar/lila) - Free chess game using HTML5 & websockets built with Scala, Play 2.8, MongoDB and Elasticsearch.
+- [Pip](https://playpip.io) - Single-player Texas Hold'em against AI opponents with distinct playing styles. Play money only, no account needed, installs as a PWA and works offline. [Source](https://github.com/playpip/pip-web), MIT.
 - [Wolfcha](https://github.com/oil-oil/wolfcha) - AI-powered Werewolf (Mafia) social deduction game where every player is controlled by top LLMs. Built with Next.js and TypeScript.
 
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ A selection of major game studios, publishers, etc. using GitHub:
 - [Kriegspiel](https://github.com/binarymax/kriegspiel) - The game of imperfect information, the Kriegspiel chess variant.
 - [Chessmata](https://github.com/jonradoff/chessmata) - Open-source multiplayer chess platform for humans and AI agents, with real-time WebSocket gameplay, Elo-based matchmaking, 3D browser board (Three.js), MCP server, and UCI-compatible CLI. Built with Go and React.
 - [Lichess](https://github.com/ornicar/lila) - Free chess game using HTML5 & websockets built with Scala, Play 2.8, MongoDB and Elasticsearch.
-- [Pip](https://playpip.io) - Single-player Texas Hold'em against AI opponents with distinct playing styles. Play money only, no account needed, installs as a PWA and works offline. [Source](https://github.com/playpip/pip-web), MIT.
+- [Pip](https://github.com/playpip/pip-web) - Single-player Texas Hold'em against AI opponents with distinct playing styles. Play money only. Runs in the browser, installs as a PWA and works offline. Built with Next.js and TypeScript.
 - [Wolfcha](https://github.com/oil-oil/wolfcha) - AI-powered Werewolf (Mafia) social deduction game where every player is controlled by top LLMs. Built with Next.js and TypeScript.
 
 


### PR DESCRIPTION
Adds [Pip](https://playpip.io) to `## Browser-Based` → `### Boardgame`, placed alphabetically after Lichess.

Pip is a single-player Texas Hold'em game that runs in the browser against named AI opponents with distinct playing styles. Play money only — no account, no download, nothing to buy. It installs as a PWA and works offline, with no backend at all.

**Source code:** https://github.com/playpip/pip-web — public, MIT licenced. The poker engine, the AI and the shuffle are all in there and readable.

One line added to an existing section, in the `- [Name](link) - Description.` format `awesome-lint` expects.